### PR TITLE
Add support for installing and using plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "svg"
   ],
   "dependencies": {
+    "arrify": "^1.0.0",
     "get-stdin": "^4.0.1",
     "imagemin": "^3.2.0",
     "meow": "^3.3.0",


### PR DESCRIPTION
Add support for using globally-installed plugins

To override the default plugins, add the flag `--plugin` (alias `-P`) one or
more times.

    imagemin [--plugin <plugin-name>...] ...
    imagemin [-P <plugin-name>...] ...

  e.g. `imagemin -P pngquant -P jpegtran`

Install plugins with `npm install -g imagemin-<plugin-name>`.