### PR TITLE
fix io ambiguities and add --verbose

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -76,8 +76,16 @@ function run(src, dest, destName) {
 				plugin = Imagemin.svgo();
 				break;
 			default:
+				// workaround pngquant bug
+				var opts = {};
+				for (var key in cli.flags) {
+					if (name !== 'pngquant' && key !== 'verbose') {
+						opts[key] = cli.flags[key];
+					}
+				}
+
 				try {
-					plugin = require('imagemin-' + name)(cli.flags);
+					plugin = require('imagemin-' + name)(opts);
 				} catch (err) {
 					exitWithMessage([
 						'Unknown plugin ' + name,

--- a/cli.js
+++ b/cli.js
@@ -5,30 +5,30 @@ var path = require('path');
 var arrify = require('arrify');
 var meow = require('meow');
 var getStdin = require('get-stdin');
-var pathExists = require('path-exists');
 var Imagemin = require('imagemin');
 
 var cli = meow({
 	help: [
-		'Usage',
-		'  $ imagemin <file> <directory>',
-		'  $ imagemin <directory> <output>',
-		'  $ imagemin <file> > <output>',
-		'  $ cat <file> | imagemin > <output>',
-		'  $ imagemin [--plugin <plugin-name>...] ...',
+		'Usage: imagemin [OPTION]... <in-file> <out-file>',
+		'  or   imagemin [OPTION]... <in-file> > <output>',
+		'  or   imagemin [OPTION]... [-o output-directory] <in-file>...',
+		'  or   imagemin [OPTION]... < <input> > <output>',
 		'',
-		'Example',
-		'  $ imagemin images/* build',
-		'  $ imagemin images build',
-		'  $ imagemin foo.png > foo-optimized.png',
-		'  $ cat foo.png | imagemin > foo-optimized.png',
-		'  $ imagemin -P pngquant foo.png > foo-optimized.png',
+		'Examples',
+		'  imagemin in.png out.png',
+		'  imagemin images/* build',
+		'  imagemin images build',
+		'  imagemin foo.png > foo-optimized.png',
+		'  imagemin < foo.png > foo-optimized.png',
+		'  imagemin -P pngquant foo.png > foo-optimized.png',
 		'',
 		'Options',
-		'  -P, --plugin                        Override the default plugins',
-		'  -i, --interlaced                    Interlace gif for progressive rendering',
-		'  -o, --optimizationLevel <number>    Optimization level between 0 and 7',
-		'  -p, --progressive                   Lossless conversion to progressive'
+		'  -p, --plugin                        override the default plugins',
+		'  -o, --output                        specify the output directory',
+		'      --interlaced                    interlace gif for progressive rendering',
+		'      --optimization-level <number>   optimization level between 0 and 7',
+		'      --progressive                   lossless conversion to progressive',
+		'  -h, --help                          show this help'
 	]
 }, {
 	boolean: [
@@ -41,28 +41,21 @@ var cli = meow({
 		'install'
 	],
 	alias: {
-		P: 'plugin',
-		i: 'interlaced',
-		o: 'optimizationLevel',
-		p: 'progressive'
+		p: 'plugin',
+		o: 'output'
 	}
 });
 
-function isFile(path) {
-	if (/^[^\s]+\.\w*$/.test(path)) {
-		return true;
-	}
-
-	try {
-		return fs.statSync(path).isFile();
-	} catch (err) {
-		return false;
-	}
+function exitWithMessage(message) {
+	console.error(Array.isArray(message) ? message.join('\n') : message);
+	process.exit(1);
 }
 
 var DEFAULT_PLUGINS = ['gifsicle', 'jpegtran', 'optipng', 'svgo'];
+var cwd = process.cwd();
 
-function run(src, dest) {
+function run(src, dest, destName) {
+
 	var plugins = cli.flags.plugin ? arrify(cli.flags.plugin) : DEFAULT_PLUGINS;
 	var imagemin = new Imagemin().src(src);
 
@@ -81,14 +74,13 @@ function run(src, dest) {
 				try {
 					plugin = require('imagemin-' + name)(cli.flags);
 				} catch (err) {
-					console.error([
+					exitWithMessage([
 						'Unknown plugin ' + name,
 						'',
 						'Maybe you forgot to install the plugin?',
 						'You can install it with:',
-						'  $ npm install -g imagemin-' + name
-					].join('\n'));
-					process.exit(1);
+						'  npm install -g imagemin-' + name
+					]);
 				}
 				break;
 		}
@@ -96,55 +88,99 @@ function run(src, dest) {
 		imagemin.use(plugin);
 	});
 
-	if (process.stdout.isTTY) {
-		imagemin.dest(dest ? dest : 'build');
+	var isBuffer = src instanceof Buffer;
+	var useStdout = !process.stdout.isTTY
+			// dest was not provided?
+			&& !dest
+			// src is a buffer or single file?
+			&& (isBuffer || src.length === 1);
+
+	if (!useStdout) {
+		if (!dest) {
+			exitWithMessage([
+					'Please specify an output location.',
+					'',
+					'Examples:',
+					'',
+					'  imagemin in.png out.png',
+					'  imagemin file1.png file2.png -o out'
+				]);
+		}
+
+		imagemin.dest(dest);
 	}
 
 	imagemin.run(function (err, files) {
 		if (err) {
-			console.error(err.message);
-			process.exit(1);
+			exitWithMessage(err.message);
 		}
 
-		if (!process.stdout.isTTY) {
+		if (useStdout) {
 			files.forEach(function (file) {
 				process.stdout.write(file.contents);
 			});
 		}
 	});
+
+	var streams = imagemin.streams;
+	var srcStream = streams[0];
+	srcStream.on('data', function (file) {
+		if (destName) {
+			file.path = path.join(path.dirname(file.path), destName);
+		}
+	});
 }
 
 if (!cli.input.length && process.stdin.isTTY) {
-	console.error([
+	exitWithMessage([
 		'Provide at least one file to optimize',
 		'',
-		'Example',
-		'  imagemin images/* build',
+		'Examples:',
+		'  imagemin in.png out.png',
+		'  imagemin images/* -o build',
 		'  imagemin foo.png > foo-optimized.png',
 		'  cat foo.png | imagemin > foo-optimized.png'
-	].join('\n'));
-
-	process.exit(1);
+	]);
 }
 
 if (cli.input.length) {
-	var src = cli.input;
-	var dest;
-
-	if (src.length > 1 && !isFile(src[src.length - 1])) {
-		dest = src[src.length - 1];
-		src.pop();
+	var files = cli.input;
+	var src;
+	var dest = cli.flags.output;
+	var destName;
+	if (!dest && files.length == 2) {
+		src = [files[0]];
+		dest = cwd;
+		destName = files[1];
+	} else {
+		src = files;
 	}
 
 	src = src.map(function (s) {
-		if (!isFile(s) && pathExists.sync(s)) {
-			return path.join(s, '**/*');
-		}
+			try {
+				if (!fs.statSync(s).isFile()) {
+					return path.join(s, '**/*');
+				}
+			} catch (e) {
+				if (e.code == 'ENOENT') {
+					console.error(s, 'does not exist');
+				} else {
+					console.error(e);
+				}
+				return undefined;
+			}
 
-		return s;
-	});
+			return s;
+		})
+		.filter(function (filename) { return filename; });
 
-	run(src, dest);
+	if (!src.length) {
+		exitWithMessage([
+			'Provide at least one input file'
+		]);
+	}
+
+	run(src, dest, destName);
 } else {
 	getStdin.buffer(run);
 }

--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,6 @@
 'use strict';
 var fs = require('fs');
 var path = require('path');
-var arrify = require('arrify');
 var meow = require('meow');
 var getStdin = require('get-stdin');
 var Imagemin = require('imagemin');
@@ -55,8 +54,11 @@ var DEFAULT_PLUGINS = ['gifsicle', 'jpegtran', 'optipng', 'svgo'];
 var cwd = process.cwd();
 
 function run(src, dest, destName) {
+	var plugins = cli.flags.plugin || DEFAULT_PLUGINS;
+	if (!Array.isArray(plugins)) {
+		plugins = [plugins];
+	}
 
-	var plugins = cli.flags.plugin ? arrify(cli.flags.plugin) : DEFAULT_PLUGINS;
 	var imagemin = new Imagemin().src(src);
 
 	plugins.forEach(function (name) {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "arrify": "^1.0.0",
     "get-stdin": "^4.0.1",
     "imagemin": "^3.2.0",
-    "meow": "^3.3.0",
-    "path-exists": "^1.0.0"
+    "meow": "^3.3.0"
   },
   "devDependencies": {
     "ava": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "svg"
   ],
   "dependencies": {
-    "arrify": "^1.0.0",
     "get-stdin": "^4.0.1",
     "imagemin": "^3.2.0",
     "meow": "^3.3.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "svg"
   ],
   "dependencies": {
+    "arrify": "^1.0.0",
     "get-stdin": "^4.0.1",
     "imagemin": "^3.2.0",
     "meow": "^3.3.0",


### PR DESCRIPTION
This is a fairly opinionated pull request, but there's nowhere to post issues on this repo.  Feel free to close or pick pieces from it :)

The main commit:
```
Previously, if running as a child process, imagemin would output to
stdout if the parent program tries to capture stdout.  This causes a
problem if the parent program normally writes to stdout itself, but
sometimes gets wrapped.  Further, writing multiple files back to stdout
just doesn't make sense.  Now, imagemin only pipes to stdout if it's
reading from stdin or if exactly one file is provided and no destination
directory is provided.  If a destination directory is provided, it is
always used.

Additionally, inferring directories was sometimes based on whether the
potential directory name had a dot in it, assuming that no directories
have dots in them. Now the destination directory is always assumed to be
a directory, regardless of its name.

One additional input format is allowed if no output (-o) is provided:

 $ imagemin in.png out.png

Finally, the single character command-line flags for optimization
parameters have been removed. '-p' now aliases '--plugin', and '-o' now
aliases '--output'.  This is done to prioritize the parameters that are
always valid, regardless of the plugins used.
```