### PR TITLE
Prefer output argument over output redirection

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -102,8 +102,8 @@ function run(src, dest) {
 		imagemin.use(plugin);
 	});
 
-	if (process.stdout.isTTY) {
-		imagemin.dest(dest ? dest : 'build');
+	if (dest) {
+		imagemin.dest(dest);
 	}
 
 	imagemin.run((err, files) => {
@@ -112,7 +112,7 @@ function run(src, dest) {
 			process.exit(1);
 		}
 
-		if (!process.stdout.isTTY) {
+		if (!dest) {
 			files.forEach(file => process.stdout.write(file.contents));
 		}
 	});


### PR DESCRIPTION
Hey everyone!
Currently the following command has no effect:

```shell
$ imagemin input-files/* output-files &> output.log
```

Since imagemin isn't associated with a terminal, it ignores `output-files` completely.
This pull request drops `isTTY` in favor of `dest` in a couple of `if`s.
With that, the above command works just fine. Does it make sense?