### PR TITLE
Add `process-exit-as-throw` rule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: node_js
+before_install:
+  - npm install --global npm
 node_js:
   - '6'
   - '4'

--- a/cli.js
+++ b/cli.js
@@ -43,7 +43,7 @@ const DEFAULT_PLUGINS = [
 
 const requirePlugins = plugins => plugins.map(x => {
 	try {
-		x = require(`imagemin-${x}`)();
+		return require(`imagemin-${x}`)();
 	} catch (err) {
 		console.error(stripIndent(`
 			Unknown plugin: ${x}
@@ -55,8 +55,6 @@ const requirePlugins = plugins => plugins.map(x => {
 		`).trim());
 		process.exit(1);
 	}
-
-	return x;
 });
 
 const run = (input, opts) => {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "devDependencies": {
     "ava": "*",
+    "eslint-plugin-node": "^1.3.0",
     "execa": "^0.4.0",
     "imagemin-pngquant": "^5.0.0",
     "pify": "^2.3.0",
@@ -66,5 +67,13 @@
     "imagemin-jpegtran": "^5.0.0",
     "imagemin-optipng": "^5.0.0",
     "imagemin-svgo": "^5.0.0"
+  },
+  "xo": {
+    "plugins": [
+      "node"
+    ],
+    "rules": {
+      "node/process-exit-as-throw": 2
+    }
   }
 }

--- a/test.js
+++ b/test.js
@@ -50,3 +50,9 @@ test('error when trying to write multiple files to stdout', async t => {
 	const err = await t.throws(execa('./cli.js', ['fixtures/test.{jpg,png}']));
 	t.is(err.stderr.trim(), 'Cannot write multiple files to stdout, specify a `--out-dir`');
 });
+
+test('throw on missing plugins', async t => {
+	const buf = await fsP.readFile('fixtures/test.png');
+	const err = await t.throws(execa('./cli.js', ['--plugin=unicorn'], {input: buf}));
+	t.regex(err.stderr, /Unknown plugin: unicorn/);
+});


### PR DESCRIPTION
As discussed in https://github.com/imagemin/imagemin-cli/pull/6#discussion-diff-61607411. This lets us return the require directly.