### PR TITLE
Update readme to match usage from npmjs.com

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,21 +16,26 @@ $ npm install --global imagemin-cli
 
 ```
 $ imagemin --help
-
+ 
   Usage
-    $ imagemin <path|glob> ... --out-dir=build [--plugin=<name> ...]
+    $ imagemin <file> <directory>
+    $ imagemin <directory> <output>
     $ imagemin <file> > <output>
     $ cat <file> | imagemin > <output>
-
+    $ imagemin [--plugin <plugin-name>...] ...
+ 
   Options
-    -p, --plugin   Override the default plugins
-    -o, --out-dir  Output directory
-
+    -P, --plugin                      Override the default plugins
+    -i, --interlaced                  Interlace gif for progressive rendering
+    -o, --optimizationLevel <number>  Optimization level between 0 and 7
+    -p, --progressive                 Lossless conversion to progressive
+ 
   Examples
-    $ imagemin images/* --out-dir=build
+    $ imagemin images/* build
+    $ imagemin images build
     $ imagemin foo.png > foo-optimized.png
     $ cat foo.png | imagemin > foo-optimized.png
-    $ imagemin --plugin=pngquant foo.png > foo-optimized.png
+    $ imagemin -P pngquant foo.png > foo-optimized.png
 ```
 
 


### PR DESCRIPTION
## What this PR does

This PR updates the usage instructions found in the [README](https://github.com/imagemin/imagemin-cli/blob/master/readme.md) to match the correct ones listed at https://www.npmjs.com/package/imagemin-cli.

## How to review this PR

- [ ] Run `imagemin images/* --out-dir=build` from the repo's instructions and see that it fails.
- [ ] Run `imagemin <file> <directory>` from the npmjs.com instructions and see that it works.