### PR TITLE
Update imagemin deps and fix new linting errors

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -44,7 +44,7 @@ const DEFAULT_PLUGINS = [
 const requirePlugins = plugins => plugins.map(x => {
 	try {
 		return require(`imagemin-${x}`)();
-	} catch (err) {
+	} catch (_) {
 		console.error(stripIndent(`
 			Unknown plugin: ${x}
 
@@ -92,9 +92,9 @@ const run = (input, opts) => {
 
 			console.log(`${files.length} ${plur('image', files.length)} minified`);
 		})
-		.catch(err => {
+		.catch(error => {
 			spinner.stop();
-			throw err;
+			throw error;
 		});
 };
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 	"dependencies": {
 		"arrify": "^1.0.1",
 		"get-stdin": "^5.0.1",
-		"imagemin": "^5.0.0",
+		"imagemin": "^6.0.0",
 		"meow": "^3.6.0",
 		"ora": "^0.2.1",
 		"plur": "^2.1.2",
@@ -57,15 +57,15 @@
 	"devDependencies": {
 		"ava": "*",
 		"execa": "^0.4.0",
-		"imagemin-pngquant": "^5.0.0",
+		"imagemin-pngquant": "^6.0.0",
 		"pify": "^2.3.0",
 		"xo": "*"
 	},
 	"optionalDependencies": {
-		"imagemin-gifsicle": "^5.0.0",
-		"imagemin-jpegtran": "^5.0.0",
-		"imagemin-optipng": "^5.0.0",
-		"imagemin-svgo": "^5.0.0"
+		"imagemin-gifsicle": "^6.0.0",
+		"imagemin-jpegtran": "^6.0.0",
+		"imagemin-optipng": "^6.0.0",
+		"imagemin-svgo": "^7.0.0"
 	},
 	"xo": {
 		"rules": {


### PR DESCRIPTION
This updates all imagemin dependencies and plugins so that we can avoid `npm audit`'s security warnings. Also took the time to fix new linting issues that arose due to new releases of XO.

All tests still pass.