### PR TITLE
fix short option error

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -24,13 +24,15 @@ const cli = meow(`
 	  $ cat foo.png | imagemin > foo-optimized.png
 	  $ imagemin --plugin=pngquant foo.png > foo-optimized.png
 `, {
-	string: [
-		'plugin',
-		'out-dir'
-	],
-	alias: {
-		p: 'plugin',
-		o: 'out-dir'
+	flags: {
+		plugin: {
+			type: 'string',
+			alias: 'p'
+		},
+		'out-dir': {
+			type: 'string',
+			alias: 'o'
+		}
 	}
 });
 


### PR DESCRIPTION
it was not work when use the short option. for example, run: imagemin -p pngquant foo.png > foo-optimize.png, but it was still to use optipng!!!