### PR TITLE
Update meow to 7.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - '12'
   - '10'
-  - '8'

--- a/cli.js
+++ b/cli.js
@@ -31,6 +31,7 @@ const cli = meow(`
 		plugin: {
 			type: 'string',
 			alias: 'p',
+			isMultiple: true,
 			default: [
 				'gifsicle',
 				'jpegtran',

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"get-stdin": "^7.0.0",
 		"imagemin": "^7.0.0",
 		"lodash.pairs": "^3.0.1",
-		"meow": "^5.0.0",
+		"meow": "^6.1.1",
 		"ora": "^4.0.3",
 		"plur": "^3.0.1",
 		"strip-indent": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"imagemin": "cli.js"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=10"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -35,7 +35,7 @@
 		"get-stdin": "^7.0.0",
 		"imagemin": "^7.0.0",
 		"lodash.pairs": "^3.0.1",
-		"meow": "^6.1.1",
+		"meow": "^7.0.1",
 		"ora": "^4.0.3",
 		"plur": "^3.0.1",
 		"strip-indent": "^3.0.0"


### PR DESCRIPTION
Updates `meow` to silence `npm audit`.

https://www.npmjs.com/advisories/1500

Multiple default options are not supported by meow 6.1.1. Support was re-added in meow 7.0.0, but that version drops support for Node 8. I don't know if keeping support for Node 8 in imagemin-cli is important, but I'd sure like to get rid of the npm audit message.