### PR TITLE
Require Node.js 12.20 and move to ESM

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,26 @@
+name: CI
+on:
+  - push
+  - pull_request
+jobs:
+  test:
+    name: Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 16
+          - 14
+          - 12
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn install --frozen-lockfile
+      - run: yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - '16'
-  - '14'
-  - '12'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
+  - '16'
   - '14'
   - '12'
-  - '10'

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
 	"license": "MIT",
 	"repository": "imagemin/imagemin-cli",
 	"funding": "https://github.com/imagemin/imagemin-cli?sponsor=1",
+	"type": "module",
 	"bin": {
 		"imagemin": "cli.js"
 	},
 	"engines": {
-		"node": ">=10"
+		"node": ">=12.20"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -31,26 +32,26 @@
 		"svg"
 	],
 	"dependencies": {
-		"arrify": "^2.0.1",
-		"get-stdin": "^8.0.0",
-		"imagemin": "^7.0.0",
+		"arrify": "^3.0.0",
+		"get-stdin": "^9.0.0",
+		"imagemin": "^8.0.0",
 		"lodash.pairs": "^3.0.1",
-		"meow": "^7.0.1",
-		"ora": "^4.0.3",
+		"meow": "^10.1.1",
+		"ora": "^5.4.1",
 		"plur": "^4.0.0",
-		"strip-indent": "^3.0.0"
+		"strip-indent": "^4.0.0"
 	},
 	"devDependencies": {
-		"ava": "^3.8.0",
-		"execa": "^4.0.0",
-		"imagemin-pngquant": "^8.0.0",
-		"xo": "^0.30.0"
+		"ava": "^3.15.0",
+		"execa": "^5.1.1",
+		"imagemin-pngquant": "^9.0.2",
+		"xo": "^0.43.0"
 	},
 	"optionalDependencies": {
 		"imagemin-gifsicle": "^7.0.0",
-		"imagemin-jpegtran": "^6.0.0",
-		"imagemin-optipng": "^7.0.0",
-		"imagemin-svgo": "^7.0.0"
+		"imagemin-jpegtran": "^7.0.0",
+		"imagemin-optipng": "^8.0.0",
+		"imagemin-svgo": "^9.0.0"
 	},
 	"xo": {
 		"rules": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,10 @@
 	},
 	"xo": {
 		"rules": {
-			"node/process-exit-as-throw": 2
+			"node/process-exit-as-throw": 2,
+			"node/no-unsupported-features/es-syntax": ["error", {
+			 	"ignores": ["dynamicImport"]
+			}]
 		}
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -29,9 +29,13 @@ $ imagemin --help
     $ imagemin foo.png > foo-optimized.png
     $ cat foo.png | imagemin > foo-optimized.png
     $ imagemin foo.png --plugin=pngquant > foo-optimized.png
-    $ imagemin foo.png --plugin.pngquant.quality={0.5,1} > foo-optimized.png
+    $ imagemin foo.png --plugin.pngquant.quality=0.5 --plugin.pngquant.quality=1 > foo-optimized.png
     $ imagemin foo.png --plugin.webp.quality=95 --plugin.webp.preset=icon > foo-icon.webp
 ```
+
+**macOS** users can also use the short CLI syntax for array arguments:
+`--plugin.pngquant.quality={0.5,1}` equals
+`--plugin.pngquant.quality=0.5 --plugin.pngquant.quality=1`
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ $ imagemin --help
     $ imagemin foo.png --plugin.webp.quality=95 --plugin.webp.preset=icon > foo-icon.webp
 ```
 
-**macOS** users can also use the short CLI syntax for array arguments:
+**non-Windows** users can also use the short CLI syntax for array arguments:
 `--plugin.pngquant.quality={0.5,1}` equals
 `--plugin.pngquant.quality=0.5 --plugin.pngquant.quality=1`
 

--- a/readme.md
+++ b/readme.md
@@ -29,10 +29,9 @@ $ imagemin --help
     $ imagemin foo.png > foo-optimized.png
     $ cat foo.png | imagemin > foo-optimized.png
     $ imagemin foo.png --plugin=pngquant > foo-optimized.png
-    $ imagemin foo.png --plugin.pngquant.quality={.5,1} > foo-optimized.png
+    $ imagemin foo.png --plugin.pngquant.quality={0.5,1} > foo-optimized.png
     $ imagemin foo.png --plugin.webp.quality=95 --plugin.webp.preset=icon > foo-icon.webp
 ```
-⚠️ To pass an argument as a number in `[0, 1]` range trim the first digit: `--param=0.05` → `--param=.05`
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -29,9 +29,10 @@ $ imagemin --help
     $ imagemin foo.png > foo-optimized.png
     $ cat foo.png | imagemin > foo-optimized.png
     $ imagemin foo.png --plugin=pngquant > foo-optimized.png
-    $ imagemin foo.png --plugin.pngquant.quality={0.1,0.2} > foo-optimized.png
+    $ imagemin foo.png --plugin.pngquant.quality={.5,1} > foo-optimized.png
     $ imagemin foo.png --plugin.webp.quality=95 --plugin.webp.preset=icon > foo-icon.webp
 ```
+⚠️ To pass an argument as a number in `[0, 1]` range trim the first digit: `--param=0.05` → `--param=.05`
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -2,14 +2,12 @@ import {promisify} from 'node:util';
 import fs from 'node:fs';
 import {dirname} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {createRequire} from 'node:module';
 import process from 'node:process';
 
 import execa from 'execa';
 import test from 'ava';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const require = createRequire(import.meta.url);
 
 process.chdir(__dirname);
 
@@ -17,7 +15,7 @@ const readFile = promisify(fs.readFile);
 
 test('show version', async t => {
 	const {stdout} = await execa('./cli.js', ['--version']);
-	t.is(stdout, require('./package.json').version);
+	t.is(stdout, JSON.parse(await readFile('./package.json')).version);
 });
 
 test('optimize a GIF', async t => {

--- a/test.js
+++ b/test.js
@@ -102,10 +102,9 @@ test('throw on missing plugins', async t => {
 test('support plugin options', async t => {
 	const input = await readFile('fixtures/test.png');
 
-	const {stdout: data} = await execa('./cli.js', ['--plugin.pngquant.dithering=1', '--plugin.pngquant.quality={0.1,0.4}'], {
+	const {stdout: data} = await execa('./cli.js', ['--plugin.pngquant.dithering=1', '--plugin.pngquant.quality=0.1', '--plugin.pngquant.quality=0.4'], {
 		input,
 		encoding: 'buffer',
-		shell: true,
 	});
 
 	const {stdout: compareData} = await execa('./cli.js', {

--- a/test.js
+++ b/test.js
@@ -1,7 +1,15 @@
-const {promisify} = require('util');
-const fs = require('fs');
-const execa = require('execa');
-const test = require('ava');
+import {promisify} from 'node:util';
+import fs from 'node:fs';
+import {dirname} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {createRequire} from 'node:module';
+import process from 'node:process';
+
+import execa from 'execa';
+import test from 'ava';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
 
 process.chdir(__dirname);
 
@@ -17,7 +25,7 @@ test('optimize a GIF', async t => {
 
 	const {stdout} = await execa('./cli.js', {
 		input,
-		encoding: 'buffer'
+		encoding: 'buffer',
 	});
 
 	t.true(stdout.length < input.length);
@@ -28,7 +36,7 @@ test('optimize a JPG', async t => {
 
 	const {stdout} = await execa('./cli.js', {
 		input,
-		encoding: 'buffer'
+		encoding: 'buffer',
 	});
 
 	t.true(stdout.length < input.length);
@@ -39,7 +47,7 @@ test('optimize a PNG', async t => {
 
 	const {stdout} = await execa('./cli.js', {
 		input,
-		encoding: 'buffer'
+		encoding: 'buffer',
 	});
 
 	t.true(stdout.length < input.length);
@@ -50,7 +58,7 @@ test('optimize a SVG', async t => {
 
 	const {stdout} = await execa('./cli.js', {
 		input,
-		encoding: 'buffer'
+		encoding: 'buffer',
 	});
 
 	t.true(stdout.length < input.length);
@@ -65,12 +73,12 @@ test('support plugins', async t => {
 
 	const {stdout: data} = await execa('./cli.js', ['--plugin=pngquant'], {
 		input,
-		encoding: 'buffer'
+		encoding: 'buffer',
 	});
 
 	const {stdout: compareData} = await execa('./cli.js', {
 		input,
-		encoding: 'buffer'
+		encoding: 'buffer',
 	});
 
 	t.true(data.length < compareData.length);
@@ -85,7 +93,7 @@ test('throw on missing plugins', async t => {
 	const input = await readFile('fixtures/test.png');
 	const error = await t.throwsAsync(execa('./cli.js', ['--plugin=unicorn'], {
 		input,
-		encoding: 'buffer'
+		encoding: 'buffer',
 	}));
 
 	t.regex(error.stderr.toString(), /Unknown plugin: unicorn/);
@@ -94,15 +102,15 @@ test('throw on missing plugins', async t => {
 test('support plugin options', async t => {
 	const input = await readFile('fixtures/test.png');
 
-	const {stdout: data} = await execa('./cli.js', ['--plugin.pngquant.dithering=1', '--plugin.pngquant.quality={.1,.4}'], {
+	const {stdout: data} = await execa('./cli.js', ['--plugin.pngquant.dithering=1', '--plugin.pngquant.quality={0.1,0.4}'], {
 		input,
 		encoding: 'buffer',
-		shell: true
+		shell: true,
 	});
 
 	const {stdout: compareData} = await execa('./cli.js', {
 		input,
-		encoding: 'buffer'
+		encoding: 'buffer',
 	});
 
 	t.true(data.length < compareData.length);

--- a/test.js
+++ b/test.js
@@ -94,9 +94,10 @@ test('throw on missing plugins', async t => {
 test('support plugin options', async t => {
 	const input = await readFile('fixtures/test.png');
 
-	const {stdout: data} = await execa('./cli.js', ['--plugin.pngquant.dithering=1'], {
+	const {stdout: data} = await execa('./cli.js', ['--plugin.pngquant.dithering=1', '--plugin.pngquant.quality={.1,.4}'], {
 		input,
-		encoding: 'buffer'
+		encoding: 'buffer',
+		shell: true
 	});
 
 	const {stdout: compareData} = await execa('./cli.js', {


### PR DESCRIPTION
* fix [num[] parsing issue](https://github.com/yargs/yargs-parser/pull/388) via `meow` update  
 closes #28
 * move to esm
 * update deps
 * apply xo v0.43.0 rules
 * drop travis, migrate to gh-actions
 
 BREAKING CHANGE: require Node.js >= 12.20